### PR TITLE
Clean up linked frameworks

### DIFF
--- a/Guanaco.xcodeproj/project.pbxproj
+++ b/Guanaco.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		BEE591BE1ADDE5CD00534F14 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEE591BD1ADDE5CD00534F14 /* Result.framework */; };
-		BEE591C01ADE05C200534F14 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEE591BF1ADE05C200534F14 /* Result.framework */; };
+		BEE591C01ADE05C200534F14 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEE591BD1ADDE5CD00534F14 /* Result.framework */; };
 		DA5023941A969B0B004175D7 /* HaveSucceeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023931A969B0B004175D7 /* HaveSucceeded.swift */; };
 		DA5023951A969B0B004175D7 /* HaveSucceeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023931A969B0B004175D7 /* HaveSucceeded.swift */; };
 		DA5023971A969B9E004175D7 /* HaveFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023961A969B9E004175D7 /* HaveFailed.swift */; };
 		DA5023981A969B9E004175D7 /* HaveFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023961A969B9E004175D7 /* HaveFailed.swift */; };
 		DA59142F1A94466E00AED74C /* HaveSucceededSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */; };
-		DA5914311A94469500AED74C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9B412491DFCC540008DD03E /* Quick.framework */; };
+		DA5914311A94469500AED74C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914301A94469500AED74C /* Quick.framework */; };
 		DA5914331A94469900AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DACBD4041A94417200BA07BE /* Nimble.framework */; };
 		DA5914351A944AE100AED74C /* AssertionMessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914341A944AE100AED74C /* AssertionMessageRecorder.swift */; };
 		DA5914371A944C4800AED74C /* HaveFailedSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914361A944C4800AED74C /* HaveFailedSpec.swift */; };
@@ -22,9 +22,9 @@
 		DA59144A1A944CA900AED74C /* AssertionMessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914341A944AE100AED74C /* AssertionMessageRecorder.swift */; };
 		DA59144B1A944CA900AED74C /* HaveFailedSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914361A944C4800AED74C /* HaveFailedSpec.swift */; };
 		DA59144C1A944CA900AED74C /* HaveSucceededSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */; };
-		DA5914621A944EDC00AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914611A944EDC00AED74C /* Nimble.framework */; };
+		DA5914621A944EDC00AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DACBD4041A94417200BA07BE /* Nimble.framework */; };
 		DA5914691A94509900AED74C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914301A94469500AED74C /* Quick.framework */; };
-		DA59146A1A94509C00AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914611A944EDC00AED74C /* Nimble.framework */; };
+		DA59146A1A94509C00AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DACBD4041A94417200BA07BE /* Nimble.framework */; };
 		DA59146B1A9450A100AED74C /* Guanaco.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914441A944C9B00AED74C /* Guanaco.framework */; };
 		DACBD3EC1A94404800BA07BE /* Guanaco.h in Headers */ = {isa = PBXBuildFile; fileRef = DACBD3EB1A94404800BA07BE /* Guanaco.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DACBD3F21A94404800BA07BE /* Guanaco.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DACBD3E61A94404800BA07BE /* Guanaco.framework */; };
@@ -54,8 +54,6 @@
 
 /* Begin PBXFileReference section */
 		BEE591BD1ADDE5CD00534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BEE591BF1ADE05C200534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C9B412491DFCC540008DD03E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5023931A969B0B004175D7 /* HaveSucceeded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceeded.swift; sourceTree = "<group>"; };
 		DA5023961A969B9E004175D7 /* HaveFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailed.swift; sourceTree = "<group>"; };
 		DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceededSpec.swift; sourceTree = "<group>"; };
@@ -64,7 +62,6 @@
 		DA5914361A944C4800AED74C /* HaveFailedSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailedSpec.swift; sourceTree = "<group>"; };
 		DA5914441A944C9B00AED74C /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5914551A944CA900AED74C /* GuanacoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuanacoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA5914611A944EDC00AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3E61A94404800BA07BE /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3EA1A94404800BA07BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DACBD3EB1A94404800BA07BE /* Guanaco.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Guanaco.h; sourceTree = "<group>"; };
@@ -121,10 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				DACBD4041A94417200BA07BE /* Nimble.framework */,
-				DA5914611A944EDC00AED74C /* Nimble.framework */,
-				C9B412491DFCC540008DD03E /* Quick.framework */,
 				DA5914301A94469500AED74C /* Quick.framework */,
-				BEE591BF1ADE05C200534F14 /* Result.framework */,
 				BEE591BD1ADDE5CD00534F14 /* Result.framework */,
 			);
 			name = Frameworks;

--- a/Guanaco.xcodeproj/project.pbxproj
+++ b/Guanaco.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		DA5023971A969B9E004175D7 /* HaveFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023961A969B9E004175D7 /* HaveFailed.swift */; };
 		DA5023981A969B9E004175D7 /* HaveFailed.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5023961A969B9E004175D7 /* HaveFailed.swift */; };
 		DA59142F1A94466E00AED74C /* HaveSucceededSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */; };
-		DA5914311A94469500AED74C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914301A94469500AED74C /* Quick.framework */; };
-		DA5914331A94469900AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5914321A94469900AED74C /* Nimble.framework */; };
+		DA5914311A94469500AED74C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9B412491DFCC540008DD03E /* Quick.framework */; };
+		DA5914331A94469900AED74C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DACBD4041A94417200BA07BE /* Nimble.framework */; };
 		DA5914351A944AE100AED74C /* AssertionMessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914341A944AE100AED74C /* AssertionMessageRecorder.swift */; };
 		DA5914371A944C4800AED74C /* HaveFailedSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5914361A944C4800AED74C /* HaveFailedSpec.swift */; };
 		DA59143F1A944C9B00AED74C /* Guanaco.h in Headers */ = {isa = PBXBuildFile; fileRef = DACBD3EB1A94404800BA07BE /* Guanaco.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -55,17 +55,15 @@
 /* Begin PBXFileReference section */
 		BEE591BD1ADDE5CD00534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = External/Result/build/Debug/Result.framework; sourceTree = "<group>"; };
 		BEE591BF1ADE05C200534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "../../Library/Developer/Xcode/DerivedData/Guanaco-gubvherbhfybamesxgazocjrszub/Build/Products/Debug/Result.framework"; sourceTree = "<group>"; };
+		C9B412491DFCC540008DD03E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../Library/Developer/Xcode/DerivedData/Guanaco-ahvhcttylybvxndoojdjwbixrwje/Build/Products/Debug-iphonesimulator/Quick.framework"; sourceTree = "<group>"; };
 		DA5023931A969B0B004175D7 /* HaveSucceeded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceeded.swift; sourceTree = "<group>"; };
 		DA5023961A969B9E004175D7 /* HaveFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailed.swift; sourceTree = "<group>"; };
 		DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceededSpec.swift; sourceTree = "<group>"; };
 		DA5914301A94469500AED74C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Guanaco-arlsxeqrahiqagdafwumtpvcbvkl/Build/Products/Debug/Quick.framework"; sourceTree = "<group>"; };
-		DA5914321A94469900AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "../External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
 		DA5914341A944AE100AED74C /* AssertionMessageRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionMessageRecorder.swift; sourceTree = "<group>"; };
 		DA5914361A944C4800AED74C /* HaveFailedSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailedSpec.swift; sourceTree = "<group>"; };
 		DA5914441A944C9B00AED74C /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5914551A944CA900AED74C /* GuanacoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuanacoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA5914571A944CF100AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = ../External/Nimble/build/Debug/Nimble.framework; sourceTree = "<group>"; };
-		DA59145D1A944D7200AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = ../External/Nimble/build/Debug/Nimble.framework; sourceTree = "<group>"; };
 		DA5914611A944EDC00AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Guanaco-arlsxeqrahiqagdafwumtpvcbvkl/Build/Products/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
 		DACBD3E61A94404800BA07BE /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3EA1A94404800BA07BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -119,13 +117,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C9D6DA5D1DF81E3B00E65759 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DACBD4041A94417200BA07BE /* Nimble.framework */,
+				DA5914611A944EDC00AED74C /* Nimble.framework */,
+				C9B412491DFCC540008DD03E /* Quick.framework */,
+				DA5914301A94469500AED74C /* Quick.framework */,
+				BEE591BF1ADE05C200534F14 /* Result.framework */,
+				BEE591BD1ADDE5CD00534F14 /* Result.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DACBD3DC1A94404800BA07BE = {
 			isa = PBXGroup;
 			children = (
-				BEE591BF1ADE05C200534F14 /* Result.framework */,
-				BEE591BD1ADDE5CD00534F14 /* Result.framework */,
 				DACBD3E81A94404800BA07BE /* Guanaco */,
 				DACBD3F51A94404800BA07BE /* GuanacoTests */,
+				C9D6DA5D1DF81E3B00E65759 /* Frameworks */,
 				DACBD3E71A94404800BA07BE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -157,10 +167,6 @@
 		DACBD3E91A94404800BA07BE /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				DA5914611A944EDC00AED74C /* Nimble.framework */,
-				DA59145D1A944D7200AED74C /* Nimble.framework */,
-				DA5914571A944CF100AED74C /* Nimble.framework */,
-				DACBD4041A94417200BA07BE /* Nimble.framework */,
 				DACBD3EA1A94404800BA07BE /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -180,8 +186,6 @@
 		DACBD3F61A94404800BA07BE /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				DA5914321A94469900AED74C /* Nimble.framework */,
-				DA5914301A94469500AED74C /* Quick.framework */,
 				DACBD3F71A94404800BA07BE /* Info.plist */,
 			);
 			name = "Supporting Files";

--- a/Guanaco.xcodeproj/project.pbxproj
+++ b/Guanaco.xcodeproj/project.pbxproj
@@ -53,24 +53,24 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		BEE591BD1ADDE5CD00534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = External/Result/build/Debug/Result.framework; sourceTree = "<group>"; };
-		BEE591BF1ADE05C200534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = "../../Library/Developer/Xcode/DerivedData/Guanaco-gubvherbhfybamesxgazocjrszub/Build/Products/Debug/Result.framework"; sourceTree = "<group>"; };
-		C9B412491DFCC540008DD03E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../Library/Developer/Xcode/DerivedData/Guanaco-ahvhcttylybvxndoojdjwbixrwje/Build/Products/Debug-iphonesimulator/Quick.framework"; sourceTree = "<group>"; };
+		BEE591BD1ADDE5CD00534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEE591BF1ADE05C200534F14 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9B412491DFCC540008DD03E /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5023931A969B0B004175D7 /* HaveSucceeded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceeded.swift; sourceTree = "<group>"; };
 		DA5023961A969B9E004175D7 /* HaveFailed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailed.swift; sourceTree = "<group>"; };
 		DA59142E1A94466E00AED74C /* HaveSucceededSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveSucceededSpec.swift; sourceTree = "<group>"; };
-		DA5914301A94469500AED74C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Guanaco-arlsxeqrahiqagdafwumtpvcbvkl/Build/Products/Debug/Quick.framework"; sourceTree = "<group>"; };
+		DA5914301A94469500AED74C /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5914341A944AE100AED74C /* AssertionMessageRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertionMessageRecorder.swift; sourceTree = "<group>"; };
 		DA5914361A944C4800AED74C /* HaveFailedSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HaveFailedSpec.swift; sourceTree = "<group>"; };
 		DA5914441A944C9B00AED74C /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5914551A944CA900AED74C /* GuanacoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuanacoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		DA5914611A944EDC00AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Guanaco-arlsxeqrahiqagdafwumtpvcbvkl/Build/Products/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		DA5914611A944EDC00AED74C /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3E61A94404800BA07BE /* Guanaco.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Guanaco.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3EA1A94404800BA07BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DACBD3EB1A94404800BA07BE /* Guanaco.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Guanaco.h; sourceTree = "<group>"; };
 		DACBD3F11A94404800BA07BE /* GuanacoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuanacoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DACBD3F71A94404800BA07BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DACBD4041A94417200BA07BE /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "../External/Nimble/build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		DACBD4041A94417200BA07BE /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE3CA221A96F80600CAD15A /* MatcherClosure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatcherClosure.swift; sourceTree = "<group>"; };
 		DAE3CA251A96FC5200CAD15A /* BeAnError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeAnError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */


### PR DESCRIPTION
Clean up linked framework file references, removing duplicates and specifying paths relative to the Build Products directory.