### PR TITLE
Xcode8.3 linker issues

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "antitypical/Result" ~> 3.0.0
-github "Quick/Nimble" ~> 5.0.0
+github "Quick/Nimble" ~> 6.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
-github "antitypical/Result" "3.1.0"
+github "Quick/Nimble" "v6.1.0"
+github "Quick/Quick" "v1.1.0"
+github "antitypical/Result" "3.2.1"
 github "jspahrsummers/xcconfigs" "0.10"

--- a/Guanaco.xcodeproj/project.pbxproj
+++ b/Guanaco.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 			baseConfigurationReference = C92C09681DFFB92C00233A4A /* iOS-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -559,6 +560,8 @@
 				INFOPLIST_FILE = Guanaco/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.modocache.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Guanaco;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Debug;
 		};
@@ -567,6 +570,7 @@
 			baseConfigurationReference = C92C09681DFFB92C00233A4A /* iOS-Framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -574,6 +578,8 @@
 				INFOPLIST_FILE = Guanaco/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.modocache.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Guanaco;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -584,6 +590,7 @@
 				INFOPLIST_FILE = GuanacoTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.modocache.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = GuanacoTests;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -594,6 +601,7 @@
 				INFOPLIST_FILE = GuanacoTests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.modocache.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = GuanacoTests;
+				SDKROOT = iphoneos;
 			};
 			name = Release;
 		};

--- a/Guanaco.xcodeproj/xcshareddata/xcschemes/Guanaco-iOS.xcscheme
+++ b/Guanaco.xcodeproj/xcshareddata/xcschemes/Guanaco-iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DACBD3F01A94404800BA07BE"


### PR DESCRIPTION
Resolved linking issues with latest Nimble framework due to bitcode settings.
Updated scheme for iOS framework target to only build test target when running tests.